### PR TITLE
fix: use portable timezone timestamp formatting

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: Validate
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    name: Python tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pytest
+
+      - name: Run tests
+        run: python -m pytest tests

--- a/provworkflow/activity.py
+++ b/provworkflow/activity.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from datetime import datetime
 from typing import List, Union
 
 from rdflib import Graph, URIRef, Literal
@@ -10,6 +9,7 @@ from rdflib.namespace import PROV, RDF, XSD
 from .prov_reporter import ProvReporter, PROVWF
 from .entity import Entity
 from .agent import Agent
+from .utils import now_as_xsd_datetime_stamp
 
 
 class Activity(ProvReporter):
@@ -57,7 +57,7 @@ class Activity(ProvReporter):
             uri=uri, label=label, named_graph_uri=named_graph_uri, class_uri=class_uri
         )
 
-        self.started_at_time = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S%:z")
+        self.started_at_time = now_as_xsd_datetime_stamp()
         self.ended_at_time = None
 
         self.used = used if used is not None else []
@@ -107,7 +107,7 @@ class Activity(ProvReporter):
 
         # if we don't yet have an endedAtTime recorded, make it now
         if self.ended_at_time is None:
-            self.ended_at_time = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S%:z")
+            self.ended_at_time = now_as_xsd_datetime_stamp()
 
         # all Activities have a endedAtTime
         g.add(

--- a/provworkflow/prov_reporter.py
+++ b/provworkflow/prov_reporter.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from _datetime import datetime
 from typing import Union
 
 from rdflib import Graph, URIRef, Literal
@@ -8,6 +7,7 @@ from rdflib.namespace import DCTERMS, PROV, OWL, RDF, RDFS, XSD
 
 from .exceptions import ProvWorkflowException
 from .namespace import PROVWF, PWFS
+from .utils import now_as_xsd_datetime_stamp
 
 
 class class_or_instance_method(classmethod):
@@ -95,7 +95,7 @@ class ProvReporter:
             self.version_uri = self.uri
 
         self.created = Literal(
-            datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S%:z"),
+            now_as_xsd_datetime_stamp(),
             datatype=XSD.dateTimeStamp,
         )
 

--- a/provworkflow/utils.py
+++ b/provworkflow/utils.py
@@ -7,6 +7,11 @@ from rdflib import Graph, URIRef, BNode, Literal
 from rdflib.namespace import DCTERMS, PROV, RDF, XSD
 
 
+def now_as_xsd_datetime_stamp() -> str:
+    """Return a local timezone-aware timestamp for xsd:dateTimeStamp values."""
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
 def query_sop_sparql(named_graph_uri, query, update=False):
     """
     Perform read and write SPARQL queries against a Surround Ontology Platform (SOP) instance

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import provworkflow.utils as utils
+
+
+def test_now_as_xsd_datetime_stamp_uses_portable_isoformat(monkeypatch):
+    class FakeDateTime:
+        @classmethod
+        def now(cls):
+            return cls()
+
+        def astimezone(self):
+            return self
+
+        def isoformat(self, timespec):
+            assert timespec == "seconds"
+            return "2026-06-19T15:31:14+08:00"
+
+        def strftime(self, _format):
+            raise AssertionError("strftime should not be used for timezone formatting")
+
+    monkeypatch.setattr(utils, "datetime", FakeDateTime)
+
+    assert utils.now_as_xsd_datetime_stamp() == "2026-06-19T15:31:14+08:00"


### PR DESCRIPTION
Python's strftime implementation depends on the platform C runtime. The %:z directive works on Linux/glibc and produces timezone offsets with a colon, but Windows does not support that directive and raises ValueError: Invalid format string when constructing provenance timestamps.

Use datetime.isoformat(timespec="seconds") for xsd:dateTimeStamp values instead, which produces the same colon-separated timezone offset without relying on platform-specific strftime directives.

This PR also confirms the portability by running the tests in GitHub Actions on both ubuntu-latest and windows-latest.